### PR TITLE
Update `once` dependency and switch from `~` to `^`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mafintosh/end-of-stream.git"
   },
   "dependencies": {
-    "once": "~1.3.0"
+    "once": "^1.4.0"
   },
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
Currently when we install [pump](https://github.com/mafintosh/pump) module, npm downloads two different versions of `once`.

```
└─┬ pump@1.0.2 
  ├─┬ end-of-stream@1.2.0 
  │ └── once@1.3.3 
  └─┬ once@1.4.0 
    └── wrappy@1.0.2 
```

This PR fixes this problem.
