### PR TITLE
Cleanup before callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-var once = require('once');
-
-var noop = function() {};
-
 var isRequest = function(stream) {
 	return stream.setHeader && typeof stream.abort === 'function';
 };

--- a/index.js
+++ b/index.js
@@ -10,11 +10,18 @@ var isChildProcess = function(stream) {
 	return stream.stdio && Array.isArray(stream.stdio) && stream.stdio.length === 3
 };
 
-var eos = function(stream, opts, callback) {
+var eos = function(stream, opts, cb) {
 	if (typeof opts === 'function') return eos(stream, null, opts);
 	if (!opts) opts = {};
 
-	callback = once(callback || noop);
+	var called = false;
+
+	function callback() {
+		if (called) return;
+		called = true;
+		cleanup();
+		if (typeof cb === 'function') cb.apply(stream, arguments);
+	}
 
 	var ws = stream._writableState;
 	var rs = stream._readableState;
@@ -27,21 +34,21 @@ var eos = function(stream, opts, callback) {
 
 	var onfinish = function() {
 		writable = false;
-		if (!readable) callback.call(stream);
+		if (!readable) callback();
 	};
 
 	var onend = function() {
 		readable = false;
-		if (!writable) callback.call(stream);
+		if (!writable) callback();
 	};
 
 	var onexit = function(exitCode) {
-		callback.call(stream, exitCode ? new Error('exited with error code: ' + exitCode) : null);
+		callback(exitCode ? new Error('exited with error code: ' + exitCode) : null);
 	};
 
 	var onclose = function() {
-		if (readable && !(rs && rs.ended)) return callback.call(stream, new Error('premature close'));
-		if (writable && !(ws && ws.ended)) return callback.call(stream, new Error('premature close'));
+		if (readable && !(rs && rs.ended)) return callback(new Error('premature close'));
+		if (writable && !(ws && ws.ended)) return callback(new Error('premature close'));
 	};
 
 	var onrequest = function() {
@@ -65,7 +72,7 @@ var eos = function(stream, opts, callback) {
 	if (opts.error !== false) stream.on('error', callback);
 	stream.on('close', onclose);
 
-	return function() {
+	function cleanup() {
 		stream.removeListener('complete', onfinish);
 		stream.removeListener('abort', onclose);
 		stream.removeListener('request', onrequest);
@@ -77,7 +84,9 @@ var eos = function(stream, opts, callback) {
 		stream.removeListener('end', onend);
 		stream.removeListener('error', callback);
 		stream.removeListener('close', onclose);
-	};
+	}
+
+	return cleanup;
 };
 
 module.exports = eos;

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "type": "git",
     "url": "git://github.com/mafintosh/end-of-stream.git"
   },
-  "dependencies": {
-    "once": "^1.4.0"
-  },
   "scripts": {
     "test": "node test.js"
   },


### PR DESCRIPTION
Being a good citizen and cleaning up after oneself.

It seemed that `once` wasn't adding much since this already had to wrap the callback.

Not sure how to test this that doesn't rely on checking event emitter internals which seems brittle.