### PR TITLE
allow "premature close" for non-core streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ var eos = function(stream, opts, callback) {
 	};
 
 	var onclose = function() {
-		if (readable && !(rs && rs.ended)) return callback.call(stream, new Error('premature close'));
-		if (writable && !(ws && ws.ended)) return callback.call(stream, new Error('premature close'));
+		if (readable && rs && !rs.ended) return callback.call(stream, new Error('premature close'));
+		if (writable && ws && !ws.ended) return callback.call(stream, new Error('premature close'));
 	};
 
 	var onrequest = function() {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var eos = require('./index');
 
-var expected = 8;
+var expected = 9;
 var fs = require('fs');
 var cp = require('child_process');
 var net = require('net');
@@ -80,7 +80,23 @@ var server = net.createServer(function(socket) {
 	});
 });
 
-setTimeout(function() {
+var EE = require('events').EventEmitter;
+var customStream = new EE();
+customStream.readable = true;
+eos(customStream, function(er) {
+	if (er) {
+		throw er;
+	}
+	expected--;
+	if (!expected) process.exit(0);
+});
+customStream.emit('close');
+customStream.emit('end');
+
+var timeout = setTimeout(function() {
 	assert(expected === 0);
 	process.exit(0);
 }, 1000);
+
+// don't keep the process open unnecessarily
+if (typeof timeout.unref === 'function') timeout.unref();


### PR DESCRIPTION
Fix #11

The timing of "close" events is implementation-specific.  For core
streams, it's reliably possible to determine if a close event is coming
in advance of the stream actually being "done".

However, if a stream doesn't have a _readableState or _writableState
property, then it's impossible to determine if the close is "premature"
or not.