### PR TITLE
Add failing pumpify test

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   "homepage": "https://github.com/mafintosh/end-of-stream",
   "main": "index.js",
   "author": "Mathias Buus <mathiasbuus@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "pumpify": "^1.3.5",
+    "through2": "^2.0.3"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,10 +1,13 @@
 var assert = require('assert');
 var eos = require('./index');
 
-var expected = 8;
+var expected = 10;
 var fs = require('fs');
 var cp = require('child_process');
 var net = require('net');
+
+var pumpify = require('pumpify');
+var through = require('through2');
 
 var ws = fs.createWriteStream('/dev/null');
 eos(ws, function(err) {
@@ -78,6 +81,19 @@ var server = net.createServer(function(socket) {
 		assert(this === socket);
 		if (!expected) process.exit(0);
 	});
+});
+
+var rs4 =	fs.createReadStream('/dev/random');
+var pumpifyErr = pumpify(
+	through(),
+	through(function(chunk, _, cb) {
+		cb(new Error('test'));
+	}),
+	fs.createWriteStream('/dev/null')
+)
+eos(rs4.pipe(pumpifyErr), function(err) {
+	assert(err);
+	assert(err.message !== 'premature close', 'does not close with premature close');
 });
 
 setTimeout(function() {


### PR DESCRIPTION
Hey @mafintosh, I just ran into this issue within the published release of gulp 4.  It seems that using pumpify with end-of-stream swallows any errors that happen in the middle of the pumpify stream and instead emit a "premature close" error.

I've created a simplified reproduction case in the tests but I'm not too sure which module needs the fix or what to actually fix.  Thoughts?

cc @erikkemperman